### PR TITLE
Allow config of service name

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,8 +7,9 @@ default['errbit']['port']         = '3000'
 default['errbit']['revision']     = 'd5337194fc2e75020e4a9558a3ae0a09921d9580' # master HEAD on Aug 23, 2015
 default['errbit']['pid_file']     = pid_file
 
-default['errbit']['shallow_clone'] = false
-default['errbit']['use_monit']     = true
+default['errbit']['shallow_clone']      = false
+default['errbit']['use_monit']          = true
+default['errbit']['monit_service_name'] = 'errbit'
 
 default['errbit']['environment'] = {
   'PORT'                              => default['errbit']['port'],

--- a/recipes/monit.rb
+++ b/recipes/monit.rb
@@ -6,7 +6,7 @@ include_recipe "monit_wrapper::default"
 t = resources(:template => "/etc/default/monit")
 t.cookbook "errbit-server"
 
-_service_name = 'errbit'
+_service_name = node['errbit']['monit_service_name']
 _command_line = '/opt/errbit/unicorn.sh'
 
 monit_wrapper_monitor _service_name do
@@ -23,4 +23,3 @@ monit_wrapper_service _service_name do
   subscribes :restart, "monit_wrapper_monitor[#{_service_name}]", :delayed
   subscribes :restart, "monit_wrapper_notify_if_not_running[#{_service_name}]", :delayed
 end
-


### PR DESCRIPTION
My base recipie sets monit up based on the node name, which happened to be `errbit`, so this conflicted... this makes it configurable.
