### PR TITLE
Update default ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Attributes
 * `node['errbit']['group']` - system group for running Errbit Unicorn (default: errbit)
 * `node['errbit']['ruby_version']` - MRI version to install using rbenv (default: 2.2.2)
 * `node['errbit']['port']` - Listening port of Errbit service (default: 3000)
-* `node['errbit']['revision']` - Errbit revision/refs to deploy. (default: d5337194fc2e75020e4a9558a3ae0a09921d9580, master HEAD on Aug 23, 2015)
+* `node['errbit']['revision']` - Errbit revision/refs to deploy. (default: f1937f6928cad3122fc9b90b066152cbaf9e692e, master HEAD on Sept 21, 2015)
 * `node['errbit']['environment']` - Environment variables for Errbit. See also next section.
 * `node['errbit']['shallow_clone']` - Enable shallow clone when git checkout errbit. Useful if you use master branch. (default: false)
 * `node['errbit']['use_monit']` - Enable unicorn service management with monit. (default: true)
@@ -58,7 +58,7 @@ https://github.com/errbit/errbit/blob/master/docs/configuration.md
 
 Default values in this recipe is changed only the following:
 
-#### ERRBIT_EMAIL_AT_NOTICES 
+#### ERRBIT_EMAIL_AT_NOTICES
 
 Errbit notifies watchers via email after the set number of occurances of the same error.
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,7 +4,7 @@ default['errbit']['user']         = 'errbit'
 default['errbit']['group']        = 'errbit'
 default['errbit']['ruby_version'] = '2.2.2'
 default['errbit']['port']         = '3000'
-default['errbit']['revision']     = 'd5337194fc2e75020e4a9558a3ae0a09921d9580' # master HEAD on Aug 23, 2015
+default['errbit']['revision']     = 'f1937f6928cad3122fc9b90b066152cbaf9e692e' # master HEAD on Sept 21, 2015
 default['errbit']['pid_file']     = pid_file
 
 default['errbit']['shallow_clone'] = false


### PR DESCRIPTION
`d5337194fc2e75020e4a9558a3ae0a09921d9580` doesn't seem to exist anymore: 

```
[2015-09-21T14:16:41+00:00] ERROR: deploy[/opt/errbit] (errbit-server::app line 20) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '128'
---- Begin output of git fetch origin && git fetch origin --tags && git reset --hard d5337194fc2e75020e4a9558a3ae0a09921d9580 ----
STDOUT:
STDERR: fatal: Could not parse object 'd5337194fc2e75020e4a9558a3ae0a09921d9580'.
---- End output of git fetch origin && git fetch origin --tags && git reset --hard d5337194fc2e75020e4a9558a3ae0a09921d9580 ----
Ran git fetch origin && git fetch origin --tags && git reset --hard d5337194fc2e75020e4a9558a3ae0a09921d9580 returned 128
```

Didn't see it over [here](https://github.com/errbit/errbit/commits/master) either; must have got yanked.
